### PR TITLE
[Refactor] S3 파라미터 VO 객체화

### DIFF
--- a/src/main/java/org/websoso/s3/config/S3AccessConfig.java
+++ b/src/main/java/org/websoso/s3/config/S3AccessConfig.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.websoso.s3.exception.AwsCredentialsNotFoundException;
 import org.websoso.s3.exception.AwsRegionNotFoundException;
+import org.websoso.s3.modle.AccessKey;
+import org.websoso.s3.modle.SecretKey;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -27,8 +29,8 @@ public class S3AccessConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(S3AccessConfig.class);
 
-    private String accessKey;
-    private String secretKey;
+    private AccessKey accessKey;
+    private SecretKey secretKey;
     private Region region = Region.AP_NORTHEAST_2;
     private AwsCredentialsProvider credentialsProvider;
 
@@ -79,16 +81,8 @@ public class S3AccessConfig {
          * @throws IllegalArgumentException 액세스 키 또는 시크릿 키가 null이거나 빈 문자열인 경우
          */
         public Builder withCredentials(String accessKey, String secretKey) {
-            if (accessKey == null || accessKey.isBlank()) {
-                throw new IllegalArgumentException("Access key must not be null or empty");
-            }
-
-            if (secretKey == null || secretKey.isBlank()) {
-                throw new IllegalArgumentException("Secret key must not be null or empty");
-            }
-
-            config.accessKey = accessKey;
-            config.secretKey = secretKey;
+            config.accessKey = AccessKey.of(accessKey);
+            config.secretKey = SecretKey.of(secretKey);
             return this;
         }
 
@@ -145,7 +139,7 @@ public class S3AccessConfig {
             if (config.accessKey != null && config.secretKey != null) {
                 logger.debug("Using StaticCredentialsProvider with provided access key and secret key");
                 return StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(config.accessKey, config.secretKey)
+                        AwsBasicCredentials.create(config.accessKey.getValue(), config.secretKey.getValue())
                 );
             }
 

--- a/src/main/java/org/websoso/s3/core/ContentLength.java
+++ b/src/main/java/org/websoso/s3/core/ContentLength.java
@@ -1,0 +1,48 @@
+package org.websoso.s3.core;
+
+import java.util.Objects;
+
+final class ContentLength {
+
+    private final long value;
+
+    private ContentLength(long value) {
+        this.value = validateContentLength(value);
+    }
+
+    public static ContentLength of(long value) {
+        return new ContentLength(value);
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    private long validateContentLength(long value) {
+        if (value <= 0) {
+            throw new IllegalArgumentException("Content length must be greater than 0");
+        }
+
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ContentLength that = (ContentLength) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "ContentLength = " + value;
+    }
+
+}

--- a/src/main/java/org/websoso/s3/core/ContentType.java
+++ b/src/main/java/org/websoso/s3/core/ContentType.java
@@ -1,0 +1,68 @@
+package org.websoso.s3.core;
+
+import java.util.Objects;
+import org.websoso.s3.exception.InvalidContentTypeException;
+
+final class ContentType {
+
+    private final String value;
+
+    private ContentType(String value) {
+        this.value = validateContentType(value).toLowerCase();
+    }
+
+    public static ContentType of(String value) {
+        return new ContentType(value);
+    }
+
+    public static ContentType imageOnlyOf(String value) {
+        ContentType contentType = new ContentType(value);
+        if (!contentType.isImage()) {
+            throw new InvalidContentTypeException("Only image content types are supported");
+        }
+        return contentType;
+
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public boolean isImage() {
+        return ImageType.getAllowedMimeTypes().stream()
+                .anyMatch(type -> type.equals(value));
+    }
+
+    private String validateContentType(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidContentTypeException("Content type must not be null or empty");
+        }
+
+        // MIME 타입 패턴 검증 (type/subtype 형식)
+        if (!value.matches("^[a-zA-Z0-9-]+/[a-zA-Z0-9.-]+$")) {
+            throw new InvalidContentTypeException("Invalid content type format: " + value);
+        }
+
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ContentType that = (ContentType) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "contentType='" + value;
+    }
+
+}

--- a/src/main/java/org/websoso/s3/core/ContentType.java
+++ b/src/main/java/org/websoso/s3/core/ContentType.java
@@ -15,13 +15,12 @@ final class ContentType {
         return new ContentType(value);
     }
 
-    public static ContentType imageOnlyOf(String value) {
-        ContentType contentType = new ContentType(value);
-        if (!contentType.isImage()) {
+    public ContentType requireImage() {
+        if (!isImage()) {
             throw new InvalidContentTypeException("Only image content types are supported");
         }
-        return contentType;
 
+        return this;
     }
 
     public String getValue() {

--- a/src/main/java/org/websoso/s3/core/Key.java
+++ b/src/main/java/org/websoso/s3/core/Key.java
@@ -31,6 +31,14 @@ final class Key {
             throw new InvalidKeyException("Object key must not be null or empty");
         }
 
+        if (value.startsWith("/")) {
+            throw new InvalidKeyException("Object key must be a relative path, not absolute");
+        }
+
+        if (value.endsWith("/")) {
+            throw new InvalidKeyException("Object key must not end with a slash, file name is missing");
+        }
+
         int lengthInBytes = value.getBytes(StandardCharsets.UTF_8).length;
         if (lengthInBytes > MAX_KEY_LENGTH_BYTES) {
             throw new InvalidKeyException("Object key is too long");

--- a/src/main/java/org/websoso/s3/core/Key.java
+++ b/src/main/java/org/websoso/s3/core/Key.java
@@ -1,0 +1,101 @@
+package org.websoso.s3.core;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.websoso.s3.exception.InvalidKeyException;
+
+final class Key {
+
+    private static final int NOT_FOUND = -1;
+    private static final int INITIAL_DEPTH = 0;
+    private static final int MAX_KEY_LENGTH_BYTES = 1024;
+    private static final Pattern SAFE_CHAR_PATTERN = Pattern.compile("^[a-zA-Z0-9!\\-_.\\*'()\\/]*$");
+
+    private final String value;
+
+    private Key(String value) {
+        this.value = validateKey(value);
+    }
+
+    public static Key of(String value) {
+        return new Key(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private String validateKey(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidKeyException("Object key must not be null or empty");
+        }
+
+        int lengthInBytes = value.getBytes(StandardCharsets.UTF_8).length;
+        if (lengthInBytes > MAX_KEY_LENGTH_BYTES) {
+            throw new InvalidKeyException("Object key is too long");
+        }
+
+        if (!isValidRelativePath(value)) {
+            throw new InvalidKeyException("Invalid relative path");
+        }
+
+        if (!SAFE_CHAR_PATTERN.matcher(value).matches()) {
+            throw new InvalidKeyException("Object key must contain valid relative path");
+        }
+
+        return value;
+    }
+
+    private boolean isValidRelativePath(String path) {
+        int depth = 0;
+        int startIndex = 0;
+
+        while (startIndex < path.length()) {
+            int endIndex = path.indexOf('/', startIndex);
+            if (endIndex == NOT_FOUND) {
+                endIndex = path.length();
+            }
+
+            int segmentLength = endIndex - startIndex;
+
+            if (segmentLength == 0) {
+                startIndex = endIndex + 1;
+                continue;
+            }
+
+            if (segmentLength == 2 && path.charAt(startIndex) == '.' && path.charAt(startIndex + 1) == '.') {
+                depth--;
+                if (depth < INITIAL_DEPTH) {
+                    return false;
+                }
+            } else if (!(segmentLength == 1 && path.charAt(startIndex) == '.')) {
+                depth++;
+            }
+
+            startIndex = endIndex + 1;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Key key = (Key) o;
+        return Objects.equals(value, key.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "key = " + value;
+    }
+
+}

--- a/src/main/java/org/websoso/s3/core/S3FileService.java
+++ b/src/main/java/org/websoso/s3/core/S3FileService.java
@@ -1,6 +1,9 @@
 package org.websoso.s3.core;
 
+import org.websoso.s3.config.S3AccessConfig;
 import org.websoso.s3.exception.InvalidFileException;
+import org.websoso.s3.factory.S3ClientFactory;
+import org.websoso.s3.modle.Bucket;
 import org.websoso.s3.modle.S3UploadResponse;
 import org.websoso.s3.modle.S3UploadResult;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -22,9 +25,11 @@ public class S3FileService implements S3DefaultService {
     private final S3Reader reader;
 
     public S3FileService(S3Client s3Client, String bucket) {
-        uploader = new S3Uploader(s3Client, bucket);
-        remover = new S3Remover(s3Client, bucket);
-        reader = new S3Reader(s3Client, bucket);
+        Bucket bucketWrapper = Bucket.of(bucket);
+
+        uploader = new S3Uploader(s3Client, bucketWrapper);
+        remover = new S3Remover(s3Client, bucketWrapper);
+        reader = new S3Reader(s3Client, bucketWrapper);
     }
 
     /**

--- a/src/main/java/org/websoso/s3/core/S3FileService.java
+++ b/src/main/java/org/websoso/s3/core/S3FileService.java
@@ -93,9 +93,8 @@ public class S3FileService implements S3DefaultService {
 
         validateKey(key);
         validateInputStream(inputStream);
-        validateContentLength(contentLength);
 
-        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.of(contentType), contentLength);
+        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.of(contentType), ContentLength.of(contentLength));
 
         if (!response.isSuccess()) {
             S3UploadResult.fail(response);
@@ -133,12 +132,6 @@ public class S3FileService implements S3DefaultService {
     private void validateInputStream(InputStream inputStream) {
         if (inputStream == null) {
             throw new IllegalArgumentException("InputStream must not be null or empty");
-        }
-    }
-
-    private void validateContentLength(long contentLength) {
-        if (contentLength <= 0) {
-            throw new InvalidFileException("Content length must be greater than 0");
         }
     }
 

--- a/src/main/java/org/websoso/s3/core/S3FileService.java
+++ b/src/main/java/org/websoso/s3/core/S3FileService.java
@@ -37,17 +37,17 @@ public class S3FileService implements S3DefaultService {
      */
     @Override
     public S3UploadResult upload(String key, File file) {
-
-        validateKey(key);
         validateFile(file);
 
-        S3UploadResponse response = uploader.upload(key, file);
+        Key parsedKey = Key.of(key);
+
+        S3UploadResponse response = uploader.upload(parsedKey, file);
 
         if (!response.isSuccess()) {
             S3UploadResult.fail(response);
         }
 
-        String url = reader.getUrl(key);
+        String url = reader.getUrl(parsedKey);
 
         return S3UploadResult.success(response, url);
     }
@@ -63,17 +63,17 @@ public class S3FileService implements S3DefaultService {
      */
     @Override
     public S3UploadResult upload(String key, File file, String contentType) {
-
-        validateKey(key);
         validateFile(file);
 
-        S3UploadResponse response = uploader.upload(key, file, ContentType.of(contentType));
+        Key parsedKey = Key.of(key);
+
+        S3UploadResponse response = uploader.upload(parsedKey, file, ContentType.of(contentType));
 
         if (!response.isSuccess()) {
             S3UploadResult.fail(response);
         }
 
-        String url = reader.getUrl(key);
+        String url = reader.getUrl(parsedKey);
 
         return S3UploadResult.success(response, url);
     }
@@ -90,17 +90,17 @@ public class S3FileService implements S3DefaultService {
      */
     @Override
     public S3UploadResult upload(String key, InputStream inputStream, String contentType, long contentLength) {
-
-        validateKey(key);
         validateInputStream(inputStream);
 
-        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.of(contentType), ContentLength.of(contentLength));
+        Key parsedKey = Key.of(key);
+
+        S3UploadResponse response = uploader.upload(parsedKey, inputStream, ContentType.of(contentType), ContentLength.of(contentLength));
 
         if (!response.isSuccess()) {
             S3UploadResult.fail(response);
         }
 
-        String url = reader.getUrl(key);
+        String url = reader.getUrl(parsedKey);
 
         return S3UploadResult.success(response, url);
 
@@ -108,15 +108,7 @@ public class S3FileService implements S3DefaultService {
 
     @Override
     public boolean delete(String key) {
-        validateKey(key);
-
-        return remover.delete(key);
-    }
-
-    private void validateKey(String key) {
-        if (key == null || key.isBlank()) {
-            throw new IllegalArgumentException("Object key must not be null or empty");
-        }
+        return remover.delete(Key.of(key));
     }
 
     private void validateFile(File file) {

--- a/src/main/java/org/websoso/s3/core/S3FileService.java
+++ b/src/main/java/org/websoso/s3/core/S3FileService.java
@@ -66,9 +66,8 @@ public class S3FileService implements S3DefaultService {
 
         validateKey(key);
         validateFile(file);
-        validateContentType(contentType);
 
-        S3UploadResponse response = uploader.upload(key, file, contentType);
+        S3UploadResponse response = uploader.upload(key, file, ContentType.of(contentType));
 
         if (!response.isSuccess()) {
             S3UploadResult.fail(response);
@@ -94,10 +93,9 @@ public class S3FileService implements S3DefaultService {
 
         validateKey(key);
         validateInputStream(inputStream);
-        validateContentType(contentType);
         validateContentLength(contentLength);
 
-        S3UploadResponse response = uploader.upload(key, inputStream, contentType, contentLength);
+        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.of(contentType), contentLength);
 
         if (!response.isSuccess()) {
             S3UploadResult.fail(response);
@@ -135,12 +133,6 @@ public class S3FileService implements S3DefaultService {
     private void validateInputStream(InputStream inputStream) {
         if (inputStream == null) {
             throw new IllegalArgumentException("InputStream must not be null or empty");
-        }
-    }
-
-    private void validateContentType(String contentType) {
-        if (contentType == null || contentType.isBlank()) {
-            throw new InvalidFileException("Content type must not be null or empty");
         }
     }
 

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -2,6 +2,7 @@ package org.websoso.s3.core;
 
 import org.websoso.s3.core.strategy.MimeTypeDetectionStrategy;
 import org.websoso.s3.exception.InvalidImageException;
+import org.websoso.s3.modle.Bucket;
 import org.websoso.s3.modle.S3UploadResponse;
 import org.websoso.s3.modle.S3UploadResult;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -29,9 +30,11 @@ public class S3ImageService implements S3DefaultService {
     private static final Set<String> ALLOWED_IMAGE_EXTENSIONS = ImageType.getAllowedExtensions();
 
     public S3ImageService(S3Client s3Client, String bucket, MimeTypeDetectionStrategy mimeDetector) {
-        this.uploader = new S3Uploader(s3Client, bucket);
-        this.remover = new S3Remover(s3Client, bucket);
-        this.reader = new S3Reader(s3Client, bucket);
+        Bucket bucketWrapper = Bucket.of(bucket);
+
+        this.uploader = new S3Uploader(s3Client, bucketWrapper);
+        this.remover = new S3Remover(s3Client, bucketWrapper);
+        this.reader = new S3Reader(s3Client, bucketWrapper);
         this.mimeDetector = mimeDetector;
     }
 

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -15,9 +15,8 @@ import java.util.Set;
 /**
  * S3 파일 업로드 및 삭제를 위한 S3DefaultService 인터페이스의 구현체 입니다.
  * <p>
- * 타입은 정해진 이미지 타입 {@link #ALLOWED_IMAGE_MIME_TYPES} {@link #ALLOWED_IMAGE_EXTENSIONS} 만을 지원하며,
- * 업로드는 {@link File} 또는 {@link InputStream}을 통한 입력을 지원합니다.
- * 업로드 결과는 {@link S3UploadResult}로 반환됩니다.
+ * 타입은 정해진 이미지 타입 {@link #ALLOWED_IMAGE_MIME_TYPES} {@link #ALLOWED_IMAGE_EXTENSIONS} 만을 지원하며, 업로드는 {@link File} 또는
+ * {@link InputStream}을 통한 입력을 지원합니다. 업로드 결과는 {@link S3UploadResult}로 반환됩니다.
  * </p>
  */
 public class S3ImageService implements S3DefaultService {
@@ -77,7 +76,7 @@ public class S3ImageService implements S3DefaultService {
 
         Key parsedKey = Key.of(key);
 
-        S3UploadResponse response = uploader.upload(parsedKey, file, ContentType.imageOnlyOf(contentType));
+        S3UploadResponse response = uploader.upload(parsedKey, file, ContentType.of(contentType).requireImage());
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
@@ -104,7 +103,8 @@ public class S3ImageService implements S3DefaultService {
 
         Key parsedKey = Key.of(key);
 
-        S3UploadResponse response = uploader.upload(parsedKey, inputStream, ContentType.imageOnlyOf(contentType), ContentLength.of(contentLength));
+        S3UploadResponse response = uploader.upload(parsedKey, inputStream, ContentType.of(contentType).requireImage(),
+                ContentLength.of(contentLength));
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -71,9 +71,8 @@ public class S3ImageService implements S3DefaultService {
     public S3UploadResult upload(String key, File file, String contentType) {
         validateKey(key);
         validateImage(file);
-        validateContentType(contentType);
 
-        S3UploadResponse response = uploader.upload(key, file, contentType);
+        S3UploadResponse response = uploader.upload(key, file, ContentType.imageOnlyOf(contentType));
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
@@ -98,10 +97,9 @@ public class S3ImageService implements S3DefaultService {
         validateKey(key);
         validateInputStream(inputStream);
         validateImage(inputStream);
-        validateContentType(contentType);
         validateContentLength(contentLength);
 
-        S3UploadResponse response = uploader.upload(key, inputStream, contentType, contentLength);
+        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.imageOnlyOf(contentType), contentLength);
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
@@ -153,16 +151,6 @@ public class S3ImageService implements S3DefaultService {
     private void validateInputStream(InputStream inputStream) {
         if (inputStream == null) {
             throw new IllegalArgumentException("InputStream must not be null");
-        }
-    }
-
-    private void validateContentType(String contentType) {
-        if (contentType == null || contentType.isBlank()) {
-            throw new InvalidImageException("Content type must not be null or empty");
-        }
-
-        if (!ALLOWED_IMAGE_MIME_TYPES.contains(contentType.toLowerCase())) {
-            throw new InvalidImageException("Image File type not allowed: MIME type " + contentType);
         }
     }
 

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -45,16 +45,17 @@ public class S3ImageService implements S3DefaultService {
      */
     @Override
     public S3UploadResult upload(String key, File file) {
-        validateKey(key);
         validateImage(file);
 
-        S3UploadResponse response = uploader.upload(key, file);
+        Key parsedKey = Key.of(key);
+
+        S3UploadResponse response = uploader.upload(parsedKey, file);
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
         }
 
-        String url = reader.getUrl(key);
+        String url = reader.getUrl(parsedKey);
         return S3UploadResult.success(response, url);
     }
 
@@ -69,16 +70,17 @@ public class S3ImageService implements S3DefaultService {
      */
     @Override
     public S3UploadResult upload(String key, File file, String contentType) {
-        validateKey(key);
         validateImage(file);
 
-        S3UploadResponse response = uploader.upload(key, file, ContentType.imageOnlyOf(contentType));
+        Key parsedKey = Key.of(key);
+
+        S3UploadResponse response = uploader.upload(parsedKey, file, ContentType.imageOnlyOf(contentType));
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
         }
 
-        String url = reader.getUrl(key);
+        String url = reader.getUrl(parsedKey);
         return S3UploadResult.success(response, url);
     }
 
@@ -94,30 +96,24 @@ public class S3ImageService implements S3DefaultService {
      */
     @Override
     public S3UploadResult upload(String key, InputStream inputStream, String contentType, long contentLength) {
-        validateKey(key);
         validateInputStream(inputStream);
         validateImage(inputStream);
 
-        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.imageOnlyOf(contentType), ContentLength.of(contentLength));
+        Key parsedKey = Key.of(key);
+
+        S3UploadResponse response = uploader.upload(parsedKey, inputStream, ContentType.imageOnlyOf(contentType), ContentLength.of(contentLength));
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
         }
 
-        String url = reader.getUrl(key);
+        String url = reader.getUrl(parsedKey);
         return S3UploadResult.success(response, url);
     }
 
     @Override
     public boolean delete(String key) {
-        validateKey(key);
-        return remover.delete(key);
-    }
-
-    private void validateKey(String key) {
-        if (key == null || key.isBlank()) {
-            throw new IllegalArgumentException("Object key must not be null or empty");
-        }
+        return remover.delete(Key.of(key));
     }
 
     private void validateImage(File file) {

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -97,9 +97,8 @@ public class S3ImageService implements S3DefaultService {
         validateKey(key);
         validateInputStream(inputStream);
         validateImage(inputStream);
-        validateContentLength(contentLength);
 
-        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.imageOnlyOf(contentType), contentLength);
+        S3UploadResponse response = uploader.upload(key, inputStream, ContentType.imageOnlyOf(contentType), ContentLength.of(contentLength));
 
         if (!response.isSuccess()) {
             return S3UploadResult.fail(response);
@@ -151,12 +150,6 @@ public class S3ImageService implements S3DefaultService {
     private void validateInputStream(InputStream inputStream) {
         if (inputStream == null) {
             throw new IllegalArgumentException("InputStream must not be null");
-        }
-    }
-
-    private void validateContentLength(long contentLength) {
-        if (contentLength <= 0) {
-            throw new InvalidImageException("Content length must be greater than 0");
         }
     }
 

--- a/src/main/java/org/websoso/s3/core/S3Reader.java
+++ b/src/main/java/org/websoso/s3/core/S3Reader.java
@@ -1,21 +1,22 @@
 package org.websoso.s3.core;
 
+import org.websoso.s3.modle.Bucket;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 
 class S3Reader {
 
     private final S3Client s3Client;
-    private final String bucket;
+    private final Bucket bucket;
 
-    public S3Reader(S3Client s3Client, String bucket) {
+    public S3Reader(S3Client s3Client, Bucket bucket) {
         this.s3Client = s3Client;
         this.bucket = bucket;
     }
 
     public String getUrl(Key key) {
         GetUrlRequest request = GetUrlRequest.builder()
-                .bucket(bucket)
+                .bucket(bucket.getValue())
                 .key(key.getValue())
                 .build();
 

--- a/src/main/java/org/websoso/s3/core/S3Reader.java
+++ b/src/main/java/org/websoso/s3/core/S3Reader.java
@@ -13,10 +13,10 @@ public class S3Reader {
         this.bucket = bucket;
     }
 
-    public String getUrl(String key) {
+    public String getUrl(Key key) {
         GetUrlRequest request = GetUrlRequest.builder()
                 .bucket(bucket)
-                .key(key)
+                .key(key.getValue())
                 .build();
 
         return s3Client.utilities().getUrl(request).toString();

--- a/src/main/java/org/websoso/s3/core/S3Reader.java
+++ b/src/main/java/org/websoso/s3/core/S3Reader.java
@@ -3,7 +3,7 @@ package org.websoso.s3.core;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 
-public class S3Reader {
+class S3Reader {
 
     private final S3Client s3Client;
     private final String bucket;

--- a/src/main/java/org/websoso/s3/core/S3Remover.java
+++ b/src/main/java/org/websoso/s3/core/S3Remover.java
@@ -2,6 +2,7 @@ package org.websoso.s3.core;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.websoso.s3.modle.Bucket;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
@@ -10,9 +11,9 @@ class S3Remover {
     private static final Logger log = LoggerFactory.getLogger(S3Remover.class);
 
     private final S3Client s3Client;
-    private final String bucket;
+    private final Bucket bucket;
 
-    public S3Remover(S3Client s3Client, String bucket) {
+    public S3Remover(S3Client s3Client, Bucket bucket) {
         this.s3Client = s3Client;
         this.bucket = bucket;
     }
@@ -23,7 +24,7 @@ class S3Remover {
 
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-                    .bucket(bucket)
+                    .bucket(bucket.getValue())
                     .key(key.getValue())
                     .build();
 

--- a/src/main/java/org/websoso/s3/core/S3Remover.java
+++ b/src/main/java/org/websoso/s3/core/S3Remover.java
@@ -17,24 +17,24 @@ public class S3Remover {
         this.bucket = bucket;
     }
 
-    public boolean delete(String key) {
+    public boolean delete(Key key) {
 
-        log.debug("Deleting object from S3: bucket={}, key={}", bucket, key);
+        log.debug("Deleting object from S3: bucket={}, key={}", bucket, key.getValue());
 
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                     .bucket(bucket)
-                    .key(key)
+                    .key(key.getValue())
                     .build();
 
             s3Client.deleteObject(deleteObjectRequest);
 
-            log.info("Successfully deleted object from S3: bucket={}, key={}", bucket, key);
+            log.info("Successfully deleted object from S3: bucket={}, key={}", bucket, key.getValue());
 
             return true;
 
         } catch (Exception e) {
-            log.error("Failed to delete object from S3: bucket={}, key={}", bucket, key, e);
+            log.error("Failed to delete object from S3: bucket={}, key={}", bucket, key.getValue(), e);
             return false;
         }
     }

--- a/src/main/java/org/websoso/s3/core/S3Remover.java
+++ b/src/main/java/org/websoso/s3/core/S3Remover.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
-public class S3Remover {
+class S3Remover {
 
     private static final Logger log = LoggerFactory.getLogger(S3Remover.class);
 

--- a/src/main/java/org/websoso/s3/core/S3Uploader.java
+++ b/src/main/java/org/websoso/s3/core/S3Uploader.java
@@ -3,6 +3,7 @@ package org.websoso.s3.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.websoso.s3.exception.S3UploaderException;
+import org.websoso.s3.modle.Bucket;
 import org.websoso.s3.modle.S3UploadResponse;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -16,9 +17,9 @@ class S3Uploader {
     private static final Logger log = LoggerFactory.getLogger(S3Uploader.class);
 
     private final S3Client s3Client;
-    private final String bucket;
+    private final Bucket bucket;
 
-    public S3Uploader(S3Client s3Client, String bucket) {
+    public S3Uploader(S3Client s3Client, Bucket bucket) {
         this.s3Client = s3Client;
         this.bucket = bucket;
     }
@@ -29,7 +30,7 @@ class S3Uploader {
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucket)
+                    .bucket(bucket.getValue())
                     .key(key.getValue())
                     .contentLength(file.length())
                     .build();
@@ -52,7 +53,7 @@ class S3Uploader {
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucket)
+                    .bucket(bucket.getValue())
                     .key(key.getValue())
                     .contentType(contentType.getValue())
                     .contentLength(file.length())
@@ -76,7 +77,7 @@ class S3Uploader {
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucket)
+                    .bucket(bucket.getValue())
                     .key(key.getValue())
                     .contentType(contentType.getValue())
                     .contentLength(contentLength.getValue())

--- a/src/main/java/org/websoso/s3/core/S3Uploader.java
+++ b/src/main/java/org/websoso/s3/core/S3Uploader.java
@@ -46,15 +46,15 @@ public class S3Uploader {
         }
     }
 
-    public S3UploadResponse upload(String key, File file, String contentType) {
+    public S3UploadResponse upload(String key, File file, ContentType contentType) {
 
-        log.debug("Uploading file to S3: bucket={}, key={}, file={}, contentType={}", bucket, key, file.getName(), contentType);
+        log.debug("Uploading file to S3: bucket={}, key={}, file={}, contentType={}", bucket, key, file.getName(), contentType.getValue());
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(key)
-                    .contentType(contentType)
+                    .contentType(contentType.getValue())
                     .contentLength(file.length())
                     .build();
             RequestBody requestBody = RequestBody.fromFile(file);
@@ -70,15 +70,15 @@ public class S3Uploader {
         }
     }
 
-    public S3UploadResponse upload(String key, InputStream inputStream, String contentType, long contentLength) {
+    public S3UploadResponse upload(String key, InputStream inputStream, ContentType contentType, long contentLength) {
 
-        log.debug("Uploading input stream to S3: bucket={}, key={}, contentType={}, contentLength={}", bucket, key, contentType, contentLength);
+        log.debug("Uploading input stream to S3: bucket={}, key={}, contentType={}, contentLength={}", bucket, key, contentType.getValue(), contentLength);
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(key)
-                    .contentType(contentType)
+                    .contentType(contentType.getValue())
                     .contentLength(contentLength)
                     .build();
 

--- a/src/main/java/org/websoso/s3/core/S3Uploader.java
+++ b/src/main/java/org/websoso/s3/core/S3Uploader.java
@@ -23,21 +23,21 @@ public class S3Uploader {
         this.bucket = bucket;
     }
 
-    public S3UploadResponse upload(String key, File file) {
+    public S3UploadResponse upload(Key key, File file) {
 
-        log.debug("Uploading file to S3: bucket={}, key={}, file={}", bucket, key, file.getName());
+        log.debug("Uploading file to S3: bucket={}, key={}, file={}", bucket, key.getValue(), file.getName());
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
-                    .key(key)
+                    .key(key.getValue())
                     .contentLength(file.length())
                     .build();
             RequestBody requestBody = RequestBody.fromFile(file);
 
             PutObjectResponse response = s3Client.putObject(putObjectRequest, requestBody);
 
-            log.info("Successfully uploaded file to S3: bucket={}, key={}", bucket, key);
+            log.info("Successfully uploaded file to S3: bucket={}, key={}", bucket, key.getValue());
 
             return S3UploadResponse.from(response);
 
@@ -46,14 +46,14 @@ public class S3Uploader {
         }
     }
 
-    public S3UploadResponse upload(String key, File file, ContentType contentType) {
+    public S3UploadResponse upload(Key key, File file, ContentType contentType) {
 
-        log.debug("Uploading file to S3: bucket={}, key={}, file={}, contentType={}", bucket, key, file.getName(), contentType.getValue());
+        log.debug("Uploading file to S3: bucket={}, key={}, file={}, contentType={}", bucket, key.getValue(), file.getName(), contentType.getValue());
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
-                    .key(key)
+                    .key(key.getValue())
                     .contentType(contentType.getValue())
                     .contentLength(file.length())
                     .build();
@@ -61,7 +61,7 @@ public class S3Uploader {
 
             PutObjectResponse response = s3Client.putObject(putObjectRequest, requestBody);
 
-            log.info("Successfully uploaded file to S3: bucket={}, key={}", bucket, key);
+            log.info("Successfully uploaded file to S3: bucket={}, key={}", bucket, key.getValue());
 
             return S3UploadResponse.from(response);
 
@@ -70,14 +70,14 @@ public class S3Uploader {
         }
     }
 
-    public S3UploadResponse upload(String key, InputStream inputStream, ContentType contentType, ContentLength contentLength) {
+    public S3UploadResponse upload(Key key, InputStream inputStream, ContentType contentType, ContentLength contentLength) {
 
-        log.debug("Uploading input stream to S3: bucket={}, key={}, contentType={}, contentLength={}", bucket, key, contentType.getValue(), contentLength.getValue());
+        log.debug("Uploading input stream to S3: bucket={}, key={}, contentType={}, contentLength={}", bucket, key.getValue(), contentType.getValue(), contentLength.getValue());
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
-                    .key(key)
+                    .key(key.getValue())
                     .contentType(contentType.getValue())
                     .contentLength(contentLength.getValue())
                     .build();
@@ -85,7 +85,7 @@ public class S3Uploader {
             RequestBody requestBody = RequestBody.fromInputStream(inputStream, contentLength.getValue());
             PutObjectResponse response = s3Client.putObject(putObjectRequest, requestBody);
 
-            log.info("Successfully uploaded to S3: bucket={}, key={}", bucket, key);
+            log.info("Successfully uploaded to S3: bucket={}, key={}", bucket, key.getValue());
 
             return S3UploadResponse.from(response);
 

--- a/src/main/java/org/websoso/s3/core/S3Uploader.java
+++ b/src/main/java/org/websoso/s3/core/S3Uploader.java
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.model.*;
 import java.io.File;
 import java.io.InputStream;
 
-public class S3Uploader {
+class S3Uploader {
 
     private static final Logger log = LoggerFactory.getLogger(S3Uploader.class);
 

--- a/src/main/java/org/websoso/s3/core/S3Uploader.java
+++ b/src/main/java/org/websoso/s3/core/S3Uploader.java
@@ -70,19 +70,19 @@ public class S3Uploader {
         }
     }
 
-    public S3UploadResponse upload(String key, InputStream inputStream, ContentType contentType, long contentLength) {
+    public S3UploadResponse upload(String key, InputStream inputStream, ContentType contentType, ContentLength contentLength) {
 
-        log.debug("Uploading input stream to S3: bucket={}, key={}, contentType={}, contentLength={}", bucket, key, contentType.getValue(), contentLength);
+        log.debug("Uploading input stream to S3: bucket={}, key={}, contentType={}, contentLength={}", bucket, key, contentType.getValue(), contentLength.getValue());
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(key)
                     .contentType(contentType.getValue())
-                    .contentLength(contentLength)
+                    .contentLength(contentLength.getValue())
                     .build();
 
-            RequestBody requestBody = RequestBody.fromInputStream(inputStream, contentLength);
+            RequestBody requestBody = RequestBody.fromInputStream(inputStream, contentLength.getValue());
             PutObjectResponse response = s3Client.putObject(putObjectRequest, requestBody);
 
             log.info("Successfully uploaded to S3: bucket={}, key={}", bucket, key);

--- a/src/main/java/org/websoso/s3/exception/InvalidAccessKeyException.java
+++ b/src/main/java/org/websoso/s3/exception/InvalidAccessKeyException.java
@@ -1,0 +1,13 @@
+package org.websoso.s3.exception;
+
+public class InvalidAccessKeyException extends RuntimeException {
+
+    public InvalidAccessKeyException(String message) {
+        super(message);
+    }
+
+    public InvalidAccessKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/websoso/s3/exception/InvalidBucketNameException.java
+++ b/src/main/java/org/websoso/s3/exception/InvalidBucketNameException.java
@@ -1,0 +1,13 @@
+package org.websoso.s3.exception;
+
+public class InvalidBucketNameException extends RuntimeException {
+
+  public InvalidBucketNameException(String message) {
+    super(message);
+  }
+
+  public InvalidBucketNameException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/src/main/java/org/websoso/s3/exception/InvalidContentLengthException.java
+++ b/src/main/java/org/websoso/s3/exception/InvalidContentLengthException.java
@@ -1,0 +1,13 @@
+package org.websoso.s3.exception;
+
+public class InvalidContentLengthException extends RuntimeException {
+
+    public InvalidContentLengthException(String message) {
+        super(message);
+    }
+
+    public InvalidContentLengthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/websoso/s3/exception/InvalidContentTypeException.java
+++ b/src/main/java/org/websoso/s3/exception/InvalidContentTypeException.java
@@ -1,0 +1,13 @@
+package org.websoso.s3.exception;
+
+public class InvalidContentTypeException extends RuntimeException {
+
+    public InvalidContentTypeException(String message) {
+        super(message);
+    }
+
+    public InvalidContentTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/websoso/s3/exception/InvalidKeyException.java
+++ b/src/main/java/org/websoso/s3/exception/InvalidKeyException.java
@@ -1,0 +1,13 @@
+package org.websoso.s3.exception;
+
+public class InvalidKeyException extends RuntimeException {
+
+    public InvalidKeyException(String message) {
+        super(message);
+    }
+
+    public InvalidKeyException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+}

--- a/src/main/java/org/websoso/s3/exception/InvalidSecretKeyException.java
+++ b/src/main/java/org/websoso/s3/exception/InvalidSecretKeyException.java
@@ -1,0 +1,13 @@
+package org.websoso.s3.exception;
+
+public class InvalidSecretKeyException extends RuntimeException {
+
+  public InvalidSecretKeyException(String message) {
+    super(message);
+  }
+
+  public InvalidSecretKeyException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/src/main/java/org/websoso/s3/modle/AccessKey.java
+++ b/src/main/java/org/websoso/s3/modle/AccessKey.java
@@ -1,0 +1,52 @@
+package org.websoso.s3.modle;
+
+import java.util.Objects;
+import org.websoso.s3.exception.InvalidAccessKeyException;
+
+public final class AccessKey {
+
+    private final String value;
+
+    private AccessKey(String value) {
+        this.value = validateAccessKey(value);
+    }
+
+    public static AccessKey of(String value) {
+        return new AccessKey(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private String validateAccessKey(String value) {
+        requireNonEmpty(value);
+        return value;
+    }
+
+    private void requireNonEmpty(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidAccessKeyException("Access key must not be null or empty.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AccessKey accessKey = (AccessKey) o;
+        return Objects.equals(value, accessKey.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "AccessKey = " + value;
+    }
+
+}

--- a/src/main/java/org/websoso/s3/modle/AccessKey.java
+++ b/src/main/java/org/websoso/s3/modle/AccessKey.java
@@ -5,6 +5,14 @@ import org.websoso.s3.exception.InvalidAccessKeyException;
 
 public final class AccessKey {
 
+    private static final int MIN_LENGTH = 16;
+    private static final int MAX_LENGTH = 128;
+
+    private static final String PERMANENT = "AKIA";
+    private static final String TEMPORARY = "ASIA";
+
+    private static final String UPPERCASE_ALPHANUMERIC_REGEX = "^[A-Z0-9]+$";
+
     private final String value;
 
     private AccessKey(String value) {
@@ -21,12 +29,31 @@ public final class AccessKey {
 
     private String validateAccessKey(String value) {
         requireNonEmpty(value);
+        validateLength(value);
+        validateFormat(value);
         return value;
     }
 
     private void requireNonEmpty(String value) {
         if (value == null || value.isBlank()) {
             throw new InvalidAccessKeyException("Access key must not be null or empty.");
+        }
+    }
+
+    private void validateLength(String value) {
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new InvalidAccessKeyException("Access key length must be between 16 and 128 characters.");
+        }
+    }
+
+    private void validateFormat(String value) {
+        if (!value.matches(UPPERCASE_ALPHANUMERIC_REGEX)) {
+            throw new InvalidAccessKeyException("Access key must contain only uppercase letters and numbers.");
+        }
+
+        // AWS Access Key ID는 'AKIA'(일반 사용자) 또는 'ASIA'(임시 자격증명)로 시작함
+        if (!value.startsWith(PERMANENT) && !value.startsWith(TEMPORARY)) {
+            throw new InvalidAccessKeyException("Access key must start with 'AKIA' or 'ASIA'.");
         }
     }
 
@@ -48,5 +75,4 @@ public final class AccessKey {
     public String toString() {
         return "AccessKey = " + value;
     }
-
 }

--- a/src/main/java/org/websoso/s3/modle/Bucket.java
+++ b/src/main/java/org/websoso/s3/modle/Bucket.java
@@ -1,0 +1,142 @@
+package org.websoso.s3.modle;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.websoso.s3.exception.InvalidBucketNameException;
+
+public final class Bucket {
+
+    private static final int MIN_LENGTH = 3;
+    private static final int MAX_LENGTH = 63;
+
+    private static final Pattern VALID_CHARS_PATTERN = Pattern.compile("^[a-z0-9.-]+$");
+    private static final Pattern START_END_PATTERN = Pattern.compile("^[a-z0-9](.*[a-z0-9])?$");
+    private static final Pattern CONSECUTIVE_DOTS_PATTERN = Pattern.compile("\\.\\.+");
+    private static final Pattern IP_ADDRESS_PATTERN = Pattern.compile(
+            "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    );
+
+    private static final String[] FORBIDDEN_PREFIXES = {
+            "xn--",
+            "sthree-",
+            "amzn-s3-demo-"
+    };
+
+    private static final String[] FORBIDDEN_SUFFIXES = {
+            "-s3alias",
+            "--ol-s3",
+            ".mrap",
+            "--x-s3",
+            "--table-s3"
+    };
+
+    private final String value;
+
+    private Bucket(String value) {
+        this.value = validateBucket(value);
+    }
+
+    public static Bucket of(String value) {
+        return new Bucket(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private String validateBucket(String value) {
+        requireNonEmpty(value);
+        validateLength(value);
+        validateCharacters(value);
+        validateStartEnd(value);
+        checkForbiddenPatterns(value);
+        checkForbiddenPrefix(value);
+        checkForbiddenSuffix(value);
+        return value;
+    }
+
+    private void requireNonEmpty(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidBucketNameException("Bucket name must not be null or empty");
+        }
+    }
+
+    private void validateLength(String value) {
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new InvalidBucketNameException(
+                    String.format("Bucket name must be between %d and %d characters. Actual length: %d",
+                            MIN_LENGTH, MAX_LENGTH, value.length()));
+        }
+    }
+
+    private void validateCharacters(String value) {
+        if (!VALID_CHARS_PATTERN.matcher(value).matches()) {
+            throw new InvalidBucketNameException(
+                    "Bucket name can only contain lowercase letters, numbers, hyphens (-), and dots (.)");
+        }
+    }
+
+    private void validateStartEnd(String value) {
+        if (!START_END_PATTERN.matcher(value).matches()) {
+            throw new InvalidBucketNameException("Bucket name must start and end with a letter or number");
+        }
+
+        if (value.startsWith("-") || value.endsWith("-")) {
+            throw new InvalidBucketNameException("Bucket name cannot start or end with a hyphen (-)");
+        }
+
+        if (value.startsWith(".") || value.endsWith(".")) {
+            throw new InvalidBucketNameException("Bucket name cannot start or end with a dot (.)");
+        }
+    }
+
+    private void checkForbiddenPatterns(String value) {
+        if (CONSECUTIVE_DOTS_PATTERN.matcher(value).find()) {
+            throw new InvalidBucketNameException("Bucket name cannot contain consecutive dots (..)");
+        }
+        if (IP_ADDRESS_PATTERN.matcher(value).matches()) {
+            throw new InvalidBucketNameException("Bucket name cannot be formatted as an IP address");
+        }
+    }
+
+    private void checkForbiddenPrefix(String value) {
+        Arrays.stream(FORBIDDEN_PREFIXES)
+                .filter(value::startsWith)
+                .findFirst()
+                .ifPresent(prefix -> {
+                    throw new InvalidBucketNameException(
+                            String.format("Bucket name cannot start with the reserved prefix '%s'", prefix));
+                });
+    }
+
+    private void checkForbiddenSuffix(String value) {
+        Arrays.stream(FORBIDDEN_SUFFIXES)
+                .filter(value::endsWith)
+                .findFirst()
+                .ifPresent(suffix -> {
+                    throw new InvalidBucketNameException(
+                            String.format("Bucket name cannot end with the reserved suffix '%s'", suffix));
+                });
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Bucket bucket = (Bucket) o;
+        return Objects.equals(value, bucket.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "Bucket = " + value;
+    }
+
+}

--- a/src/main/java/org/websoso/s3/modle/SecretKey.java
+++ b/src/main/java/org/websoso/s3/modle/SecretKey.java
@@ -1,0 +1,52 @@
+package org.websoso.s3.modle;
+
+import java.util.Objects;
+import org.websoso.s3.exception.InvalidSecretKeyException;
+
+public final class SecretKey {
+
+    private final String value;
+
+    private SecretKey(String value) {
+        this.value = validateSecretKey(value);
+    }
+
+    public static SecretKey of(String value) {
+        return new SecretKey(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private String validateSecretKey(String value) {
+        requireNonEmpty(value);
+        return value;
+    }
+
+    private void requireNonEmpty(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidSecretKeyException("Secret key must not be null or empty.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SecretKey secretKey = (SecretKey) o;
+        return Objects.equals(value, secretKey.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "SecretKey = " + value;
+    }
+
+}

--- a/src/test/java/org/websoso/s3/core/ContentTypeTest.java
+++ b/src/test/java/org/websoso/s3/core/ContentTypeTest.java
@@ -1,0 +1,116 @@
+package org.websoso.s3.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.websoso.s3.exception.InvalidContentTypeException;
+
+class ContentTypeTest {
+
+    @Test
+    @DisplayName("ContentType 객체를 생성")
+    void createValidContentType() {
+        // Given
+        String value = "application/json";
+
+        // When
+        ContentType contentType = ContentType.of(value);
+
+        // Then
+        assertThat(contentType.getValue()).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("대문자인 경우 소문자로 변환된다.")
+    void contentTypeStoredAsLowerCase() {
+        // Given
+        String value = "IMAGE/JPEG";
+
+        // When
+        ContentType contentType = ContentType.of(value);
+
+        // Then
+        assertThat(contentType.getValue()).isNotEqualTo(value);
+        assertThat(contentType.getValue()).isEqualTo(value.toLowerCase());
+    }
+
+    @Test
+    @DisplayName("null 값으로 ContentType 객체를 생성할 수 없다.")
+    void nullValueThrowsException() {
+        // Given
+        String value = null;
+
+        // When & Then
+        assertThatThrownBy(()-> ContentType.of(value))
+                .isInstanceOf(InvalidContentTypeException.class)
+                .hasMessage("Content type must not be null or empty");
+    }
+
+    @Test
+    @DisplayName("공백 문자열로 ContentType 객체를 생성할 수 없다.")
+    void blankValueThrowsException() {
+        // Given
+        String value = "";
+
+        // When & Then
+        assertThatThrownBy(()-> ContentType.of(value))
+                .isInstanceOf(InvalidContentTypeException.class)
+                .hasMessage("Content type must not be null or empty");
+    }
+
+    @ParameterizedTest
+    @DisplayName("MIME 타입 패턴을 따르지 않은 문자열로 ContentType 객체를 생성할 수 없다.")
+    @ValueSource(strings = {"image", "image_png", "image\\jpeg", "image@"})
+    void invalidFormatThrowsException(String value) {
+        // When & Then
+        assertThatThrownBy(()-> ContentType.of(value))
+                .isInstanceOf(InvalidContentTypeException.class)
+                .hasMessage("Invalid content type format: " + value);
+    }
+
+    @Test
+    @DisplayName("ContentType 객체가 이미지 타입인지 알 수 있다.")
+    void isImageReturnsTrue() {
+        // Given
+        String imageValue = "image/png";
+        String nonImageValue = "application/json";
+
+        // When
+        ContentType imageContentType = ContentType.of(imageValue);
+        ContentType nonImageContentType = ContentType.of(nonImageValue);
+
+        // Then
+        assertThat(imageContentType.isImage()).isTrue();
+        assertThat(nonImageContentType.isImage()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미지 ContentType 객체를 생성한다.")
+    void imageOnlyOfSucceedsOnImage() {
+        // Given
+        String value = "image/png";
+
+        // When
+        ContentType contentType = ContentType.imageOnlyOf(value);
+
+        // Then
+        assertThat(contentType.getValue()).isEqualTo(value);
+        assertThat(contentType.isImage()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미지 타입이 아닌 문자열로 이미지 ContentType 객체를 생성할 수 없다.")
+    void imageOnlyOfThrowsOnNonImage() {
+        // Given
+        String value = "application/json";
+
+        // When & Then
+        assertThatThrownBy(() -> ContentType.imageOnlyOf(value))
+                .isInstanceOf(InvalidContentTypeException.class)
+                .hasMessage("Only image content types are supported");
+    }
+}

--- a/src/test/java/org/websoso/s3/core/ContentTypeTest.java
+++ b/src/test/java/org/websoso/s3/core/ContentTypeTest.java
@@ -95,7 +95,7 @@ class ContentTypeTest {
         String value = "image/png";
 
         // When
-        ContentType contentType = ContentType.imageOnlyOf(value);
+        ContentType contentType = ContentType.of(value).requireImage();
 
         // Then
         assertThat(contentType.getValue()).isEqualTo(value);
@@ -109,7 +109,7 @@ class ContentTypeTest {
         String value = "application/json";
 
         // When & Then
-        assertThatThrownBy(() -> ContentType.imageOnlyOf(value))
+        assertThatThrownBy(() -> ContentType.of(value).requireImage())
                 .isInstanceOf(InvalidContentTypeException.class)
                 .hasMessage("Only image content types are supported");
     }

--- a/src/test/java/org/websoso/s3/core/KeyTest.java
+++ b/src/test/java/org/websoso/s3/core/KeyTest.java
@@ -1,0 +1,193 @@
+package org.websoso.s3.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.websoso.s3.exception.InvalidKeyException;
+
+class KeyTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "simple-file.txt",
+            "folder/file.txt",
+            "path/to/file.json",
+            "file_with_underscore",
+            "file-with-dash",
+            "file.with.dots",
+            "file'with'quotes",
+            "file(with)parentheses",
+            "file*with*asterisk",
+            "123456789",
+            "path/with/numbers123",
+            "a",
+            "A",
+            "file!exclamation"
+    })
+    @DisplayName("Key 객체를 생성한다.")
+    void createValidKey(String validKey) {
+        // When
+        Key key = Key.of(validKey);
+
+        // Then
+        assertThat(key.getValue()).isEqualTo(validKey);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "  ", "\t", "\n"})
+    @DisplayName("null이거나 빈 문자열로 Key 객체를 생성할 수 없다.")
+    void createKeyWithNullOrEmpty(String invalidKey) {
+        // When & Then
+        assertThatThrownBy(() -> Key.of(invalidKey))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Object key must not be null or empty");
+    }
+
+    @Test
+    @DisplayName("1024 바이트의 문자열로 Key 객체를 생성할 수 있다.")
+    void createKeyWithMaxLengthValue() {
+        // Given
+        String maxLengthKey = "a".repeat(1024);
+
+        // When
+        Key key = Key.of(maxLengthKey);
+
+        // Then
+        assertThat(key.getValue()).isEqualTo(maxLengthKey);
+    }
+
+    @Test
+    @DisplayName("1024 바이트를 초과하는 문자열로 Key 객체를 생성할 수 없다.")
+    void createKeyWithTooLongValue() {
+        // Given
+        String tooLongKey = "a".repeat(1025);
+
+        // When & Then
+        assertThatThrownBy(() -> Key.of(tooLongKey))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Object key is too long");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "file with space",
+            "file@with@at",
+            "file#with#hash",
+            "file$with$dollar",
+            "file%with%percent",
+            "file^with^caret",
+            "file&with&ampersand",
+            "file+with+plus",
+            "file=with=equals",
+            "file[with]brackets",
+            "file{with}braces",
+            "file|with|pipe",
+            "file\\with\\backslash",
+            "file:with:colon",
+            "file;with;semicolon",
+            "file\"with\"quotes",
+            "file<with>angles",
+            "file,with,comma",
+            "file?with?question"
+    })
+    @DisplayName("유효하지 않은 문자로 구성된 문자열로 Key 객체를 생성할 수 없다.")
+    void createKeyWithInvalidCharacters(String invalidKey) {
+        // When & Then
+        assertThatThrownBy(() -> Key.of(invalidKey))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Object key must contain valid relative path");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "folder/file.txt",
+            "path/to/deep/file.txt",
+            "a/b/c/d/e/f",
+            "./file.txt",
+            "folder/./file.txt",
+            "folder/../folder/file.txt",
+            "a/../a/file.txt"
+    })
+    @DisplayName("유효한 상대 경로 Key 객체를 생성한다.")
+    void createKeyWithValidRelativePath(String validPath) {
+        // When
+        Key key = Key.of(validPath);
+
+        // Then
+        assertThat(key.getValue()).isEqualTo(validPath);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "../file.txt",
+            "folder/../../file.txt",
+            "../../../file.txt",
+            "a/../../../b/file.txt",
+            "folder/../../../another/file.txt"
+    })
+    @DisplayName("상위 디렉토리로 벗어나는 무효한 상대 경로로 Key 객체를 생성할 수 없다.")
+    void createKeyWithInvalidRelativePath(String invalidPath) {
+        // When & Then
+        assertThatThrownBy(() -> Key.of(invalidPath))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Invalid relative path");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "file//with//double//slash",
+            "path///triple/slash"
+    })
+    @DisplayName("빈 세그먼트를 포함해도 유효한 문자로 구성된 경로는 Key 생성에 성공한다")
+    void createKeyWhenPathContainsEmptySegmentsButIsValid(String value) {
+
+        // When
+        Key key = Key.of(value);
+
+        // Then
+        assertThat(key.getValue()).isEqualTo(value);
+    }
+
+
+    @Test
+    @DisplayName("한글로 Key객체를 생성할 수 없다.")
+    void throwExceptionWhenContainsKoreanCharacters() {
+        // Given
+        String koreanKey = "한글파일명.txt";
+
+        // When & Then
+        assertThatThrownBy(() -> Key.of(koreanKey))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Object key must contain valid relative path");
+    }
+
+    @Test
+    @DisplayName("절대 경로가 포함된 경우, Key 객체를 생성할 수 없다.")
+    void absolutePathThrowsException() {
+        // Given
+        String absolutePath = "/absolute/path";
+
+        // When & Then
+        assertThatThrownBy(() -> Key.of(absolutePath))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Object key must be a relative path, not absolute");
+    }
+
+    @Test
+    @DisplayName("파일명이 누락된 경우, Key 객체를 생성할 수 없다.")
+    void endsWithSlashThrowsException() {
+        // Given
+        String absolutePath = "path/";
+
+        // When & Then
+        assertThatThrownBy(() -> Key.of(absolutePath))
+                .isInstanceOf(InvalidKeyException.class)
+                .hasMessage("Object key must not end with a slash, file name is missing");
+    }
+}

--- a/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
+++ b/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.websoso.s3.core.strategy.PreciseMimeTypeDetectionStrategy;
 import org.websoso.s3.core.strategy.FastMimeTypeDetectionStrategy;
+import org.websoso.s3.exception.InvalidContentTypeException;
 import org.websoso.s3.exception.InvalidImageException;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -47,7 +48,7 @@ class S3ImageServiceTest {
 
         // when & then
         assertThatThrownBy(() -> imageService.upload(key, file, invalidContentType))
-                .isInstanceOf(InvalidImageException.class);
+                .isInstanceOf(InvalidContentTypeException.class);
     }
 
     @DisplayName("확장자는 jpg이더라도, 실제 MimeType이 지원되지 않는 타입이면 예외를 던진다")

--- a/src/test/java/org/websoso/s3/modle/AccessKeyTest.java
+++ b/src/test/java/org/websoso/s3/modle/AccessKeyTest.java
@@ -1,0 +1,103 @@
+package org.websoso.s3.modle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.websoso.s3.exception.InvalidAccessKeyException;
+
+class AccessKeyTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "AKIA12345678901234",
+            "ASIAABCDEFGHIJKLMNOPQRST",
+            "AKIA00000000000000",
+            "ASIA99999999999999999999"
+    })
+    @DisplayName("AccessKey 객체를 생성한다.")
+    void createValidAccessKey(String value) {
+        // When
+        AccessKey accessKey = AccessKey.of(value);
+
+        // Then
+        assertThat(accessKey.getValue()).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("null 값으로 AccessKey 객체를 생성할 수 없다.")
+    void nullValueThrowsException() {
+        // Given
+        String value = null;
+
+        // When & Then
+        assertThatThrownBy(() -> AccessKey.of(value))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key must not be null or empty.");
+    }
+
+    @Test
+    @DisplayName("빈 문자열로 AccessKey 객체를 생성할 수 없다.")
+    void blankValueThrowsException() {
+        // Given
+        String value = "  ";
+
+        // When & Then
+        assertThatThrownBy(() -> AccessKey.of(value))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key must not be null or empty.");
+    }
+
+    @Test
+    @DisplayName("길이가 16자 미만이거나 128자를 초과하는 AccessKey는 생성할 수 없다.")
+    void invalidLengthThrowsException() {
+        String toShort = "AKIA1234567890";
+        String toLong = "AKIA12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
+
+        // When & Then
+        assertThatThrownBy(() -> AccessKey.of(toShort))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key length must be between 16 and 128 characters.");
+
+        assertThatThrownBy(() -> AccessKey.of(toLong))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key length must be between 16 and 128 characters.");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 형식의 AccessKey는 생성할 수 없다.")
+    void invalidFormatThrowsException() {
+        // Given
+        String keyWithLowerCaseInside = "AKIA1234abcd5678";
+        String keyStartingWithLowerCase = "akia123456789012";
+        String specialCharKey = "ASIA1234!@#$5678";
+
+        // When & Then
+        assertThatThrownBy(() -> AccessKey.of(keyWithLowerCaseInside))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key must contain only uppercase letters and numbers.");
+
+        assertThatThrownBy(() -> AccessKey.of(keyStartingWithLowerCase))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key must contain only uppercase letters and numbers.");
+
+        assertThatThrownBy(() -> AccessKey.of(specialCharKey))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key must contain only uppercase letters and numbers.");
+    }
+
+    @Test
+    @DisplayName("AccessKey는 'AKIA' 또는 'ASIA'로 시작하지 않으면 생성할 수 없다.")
+    void invalidPrefixThrowsException() {
+        // Given
+        String keyStartingWithInvalidPrefix1 = "BKIA123456789012";
+
+        // When & Then
+        assertThatThrownBy(() -> AccessKey.of(keyStartingWithInvalidPrefix1))
+                .isInstanceOf(InvalidAccessKeyException.class)
+                .hasMessage("Access key must start with 'AKIA' or 'ASIA'.");
+    }
+}

--- a/src/test/java/org/websoso/s3/modle/BucketTest.java
+++ b/src/test/java/org/websoso/s3/modle/BucketTest.java
@@ -1,0 +1,164 @@
+package org.websoso.s3.modle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.websoso.s3.exception.InvalidBucketNameException;
+
+class BucketTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "my-bucket",
+            "bucket123",
+            "bucket.name.with.dots",
+            "abc",
+            "bucket0"
+    })
+    @DisplayName("Bucket 객체를 생성한다.")
+    void createValidBucket(String value) {
+        // When
+        Bucket bucket = Bucket.of(value);
+
+        // Then
+        assertThat(bucket.getValue()).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("null 값으로 Bucket 객체를 생성할 수 없다.")
+    void nullValueThrowsException() {
+        // Given
+        String value = null;
+
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name must not be null or empty");
+    }
+
+    @Test
+    @DisplayName("빈 문자열로 Bucket 객체를 생성할 수 없다.")
+    void blankValueThrowsException() {
+        // Given
+        String value = " ";
+
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name must not be null or empty");
+    }
+
+    @Test
+    @DisplayName("버킷 이름 길이가 3 미만이거나 63 초과인 경우 예외가 발생한다.")
+    void invalidLengthThrowsException() {
+        // Given
+        String tooShort = "ab";
+        String tooLong = "a".repeat(64);
+
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(tooShort))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessageContaining("Bucket name must be between 3 and 63 characters");
+
+        assertThatThrownBy(() -> Bucket.of(tooLong))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessageContaining("Bucket name must be between 3 and 63 characters");
+    }
+
+    @Test
+    @DisplayName("소문자, 숫자, 하이픈, 점 이외의 문자가 포함되면 예외가 발생한다.")
+    void invalidCharactersThrowsException() {
+        // Given
+        String upperCase = "BucketName";
+        String underscore = "bucket_name";
+        String specialChar = "bucket@name";
+
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(upperCase))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name can only contain lowercase letters, numbers, hyphens (-), and dots (.)");
+
+        assertThatThrownBy(() -> Bucket.of(underscore))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name can only contain lowercase letters, numbers, hyphens (-), and dots (.)");
+
+        assertThatThrownBy(() -> Bucket.of(specialChar))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name can only contain lowercase letters, numbers, hyphens (-), and dots (.)");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "-bucket",
+            "bucket-",
+            ".bucket",
+            "bucket."
+    })
+    @DisplayName("버킷 이름이 하이픈 또는 점으로 시작하거나 끝나면 예외가 발생한다.")
+    void invalidStartOrEndThrowsException(String value) {
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name must start and end with a letter or number");
+    }
+
+    @Test
+    @DisplayName("연속된 점(..)이 포함된 버킷 이름은 생성할 수 없다.")
+    void consecutiveDotsThrowsException() {
+        // Given
+        String value = "bucket..name";
+
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name cannot contain consecutive dots (..)");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "192.168.0.1",
+            "255.255.255.255"
+    })
+    @DisplayName("IP 주소 형식의 버킷 이름은 생성할 수 없다.")
+    void ipAddressFormatThrowsException(String value) {
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessage("Bucket name cannot be formatted as an IP address");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "xn--bucket",
+            "sthree-bucket",
+            "amzn-s3-demo-bucket"
+    })
+    @DisplayName("금지된 접두사로 시작하는 버킷 이름은 생성할 수 없다.")
+    void forbiddenPrefixThrowsException(String value) {
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessageContaining("Bucket name cannot start with the reserved prefix");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "bucket-s3alias",
+            "bucket--ol-s3",
+            "bucket.mrap",
+            "bucket--x-s3",
+            "bucket--table-s3"
+    })
+    @DisplayName("금지된 접미사로 끝나는 버킷 이름은 생성할 수 없다.")
+    void forbiddenSuffixThrowsException(String value) {
+        // When & Then
+        assertThatThrownBy(() -> Bucket.of(value))
+                .isInstanceOf(InvalidBucketNameException.class)
+                .hasMessageContaining("Bucket name cannot end with the reserved suffix");
+
+    }
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#10 -> dev
- close #10 

## Key Changes
### ContentType, ContentLength, Key

- `ContentType`은 이미지 타입만 허용하도록 검증 로직을 구현하였습니다. (`ImageType` 클래스 활용)  
- `ContentLength`는 `null` 또는 빈 값에 대한 검증 로직만 구현하였습니다.
- `Key`는 AWS S3 Key 명명 규칙에 기반하여 경로 유효성 검증 로직을 구현하였습니다.
  - 이때, 경로 유효성 검사를 단순 반복문이 아닌 **투 포인터 알고리즘**을 적용하여  
    시간 복잡도를 `O(N²)` → `O(N)`으로 최적화하였습니다.

### AccessKey, SecretKey, Bucket

- `AccessKey`: AWS 공식 명세에 따라 형식(접두사, 대문자+숫자 조합, 길이) 검증 로직을 구현하였습니다.
- `SecretKey`: 공식 명세가 없어 `null`, 빈 값 검증 로직만 구현하였습니다.
- `Bucket`: AWS 명세를 기반으로 버킷 이름 형식, 길이, 접두사 제한 등을 검증 로직을 구현하였습니다.


### 테스트 코드 작성

- 검증 로직이 포함된 VO에 대한 **단위 테스트** 를 작성하였습니다. 
  - 예외 발생 여부, 정상 케이스에 대한 **경계값 테스트**을 주로 작성하였습니다. 
- 단순 `Null`/`Blank`만 검증하는 VO (`ContentLength`, `SecretKey`)는 테스트 코드를 작성하지 않았습니다. 


### 구현체 접근 제어 제한

- `S3Uploader`, `S3Remover`, `S3Reader` 등의 상세 구현체 클래스는 `default` 접근 제어자로 설정하여 외부 사용을 제한하였습니다.
- 이 구현체들에서 사용하는 VO들 (`ContentType`, `ContentLength`, `Key`) 역시  
  직접 객체를 생성하지 못하도록 `default` 접근 제어자로 지정하였습니다.

## To Reviewers
`S3Client`(SDK)를 라이브러리를 사용하는 측에서 직접 생성자 주입하지 않도록 리팩토링하면 좋을것 같습니다.
`AccessConfig`만 Service에 주입하면, 내부적으로 `S3ClientFactory` 클래스를 통해 `S3Client`를 자동으로 생성 및 주입받도록 구성하면 사용성을 높이고, 라이브러리 사용자 입장에서 S3 SDK 구현체에 대한 의존을 최소화할 수 있습니다.
이에 대한 의견이 궁금합니다!

## References
- [AWS S3 Object Key Naming 가이드라인](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)
- [AWS S3 Bucket Naming 규칙](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)
- [AWS Access Key and Secret Access Key 형식](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html)
