### PR TITLE
[FEAT] 예외 패키지별 최상위 예외 클래스 도입 및 Javadoc 반영

### DIFF
--- a/src/main/java/org/websoso/s3/config/S3DetectionProperties.java
+++ b/src/main/java/org/websoso/s3/config/S3DetectionProperties.java
@@ -31,11 +31,11 @@ public class S3DetectionProperties {
     }
 
     /**
-     * MIME 감지 전략을 설정합니다. null이 들어올 경우 기본값 {@link MimeDetection#FAST}로 대체됩니다.
+     * MIME 감지 전략을 설정합니다.
      *
      * @param mimeDetection 감지 전략
      */
     public void setMimeDetection(MimeDetection mimeDetection) {
-        this.mimeDetection = (mimeDetection != null) ? mimeDetection : MimeDetection.FAST;
+        this.mimeDetection = mimeDetection;
     }
 }

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -1,5 +1,6 @@
 package org.websoso.s3.core;
 
+import org.websoso.s3.core.strategy.FastMimeTypeDetectionStrategy;
 import org.websoso.s3.core.strategy.MimeTypeDetectionStrategy;
 import org.websoso.s3.exception.validation.InvalidImageException;
 import org.websoso.s3.modle.Bucket;
@@ -35,6 +36,16 @@ public class S3ImageService implements S3DefaultService {
         this.remover = new S3Remover(s3Client, bucketWrapper);
         this.reader = new S3Reader(s3Client, bucketWrapper);
         this.mimeDetector = mimeDetector;
+    }
+
+    public S3ImageService(S3Client s3Client, String bucket) {
+        Bucket bucketWrapper = Bucket.of(bucket);
+        FastMimeTypeDetectionStrategy fastMimeTypeDetectionStrategy = new FastMimeTypeDetectionStrategy();
+
+        this.uploader = new S3Uploader(s3Client, bucketWrapper);
+        this.remover = new S3Remover(s3Client, bucketWrapper);
+        this.reader = new S3Reader(s3Client, bucketWrapper);
+        this.mimeDetector = fastMimeTypeDetectionStrategy;
     }
 
     /**

--- a/src/main/java/org/websoso/s3/exception/aws/global/AwsCredentialsNotFoundException.java
+++ b/src/main/java/org/websoso/s3/exception/aws/global/AwsCredentialsNotFoundException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.aws.global;
 
-public class AwsCredentialsNotFoundException extends RuntimeException {
+public class AwsCredentialsNotFoundException extends AwsGlobalException {
 
     public AwsCredentialsNotFoundException(String message) {
         super(message);

--- a/src/main/java/org/websoso/s3/exception/aws/global/AwsGlobalException.java
+++ b/src/main/java/org/websoso/s3/exception/aws/global/AwsGlobalException.java
@@ -1,0 +1,23 @@
+package org.websoso.s3.exception.aws.global;
+
+/**
+ * AWS 서비스와 상호작용하기 위한 전제 조건이 충족되지 않았을 때 발생하는 예외의 최상위 기본 클래스입니다.
+ * <p>
+ * 이 예외는 특정 AWS 서비스(예: S3)의 API 호출 단계 이전에 발생하는 설정 및 환경 관련 문제를 다룹니다.
+ * 주로 AWS 클라이언트 초기화나 설정 과정에서 필요한 정보가 누락되었거나 유효하지 않을 때 사용됩니다. (예: 리전 설정 문제, 자격 증명 문제)
+ *
+ * 이 클래스를 상속하는 구체적인 예외들은 어떤 전역 설정에 문제가 있는지 명확히 알려주는 역할을 합니다.
+ * (예: {@code AwsCredentialsNotFoundException}, {@code AwsRegionNotfoundException})
+ */
+
+public class AwsGlobalException extends RuntimeException {
+
+    public AwsGlobalException(String message) {
+        super(message);
+    }
+
+    public AwsGlobalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/websoso/s3/exception/aws/global/AwsRegionNotFoundException.java
+++ b/src/main/java/org/websoso/s3/exception/aws/global/AwsRegionNotFoundException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.aws.global;
 
-public class AwsRegionNotFoundException extends RuntimeException {
+public class AwsRegionNotFoundException extends AwsGlobalException {
 
     public AwsRegionNotFoundException(String message) {
         super(message);

--- a/src/main/java/org/websoso/s3/exception/aws/s3/S3OperationException.java
+++ b/src/main/java/org/websoso/s3/exception/aws/s3/S3OperationException.java
@@ -1,24 +1,30 @@
 package org.websoso.s3.exception.aws.s3;
 
 /**
- * Amazon S3와 관련된 작업 중에 발생하는 모든 오류에 대한 기본 예외 클래스입니다.
+ * Amazon S3와 관련된 작업 중에 발생하는 예외의 최상위 기본 클래스입니다.
  * <p>
  * 이 클래스는 AWS SDK에서 발생하는 클라이언트 측 오류와 서비스 측 오류를 라이브러리 사용자를 위해
  * 일관된 단일 예외 계층으로 통합하는 역할을 합니다.
  *
- * 이 예외는 크게 두 가지 주요 실패 시나리오를 구분합니다:
+ * 이 예외는 크게 두 가지 주요 실패 시나리오를 다룹니다:
  * <ul>
- * <li><b>서비스 오류 (Service Errors):</b> 요청이 S3 서비스에 성공적으로 도달했지만, 서비스 측에서
- * 요청을 처리할 수 없어 거부된 경우 (예: '버킷을 찾을 수 없음') 발생합니다. 이 경우, 예외 객체는
- * {@code awsErrorCode}, {@code awsRequestId}, {@code httpStatusCode}와 같이
- * AWS로부터 받은 상세한 컨텍스트 정보를 포함합니다.</li>
+ * <li><b>서비스 오류 (Service Errors):</b>
+ * 요청이 S3 서비스에 성공적으로 도달했지만, 서비스 측에서 요청을 처리할 수 없어 거부된 경우 (예: '버킷을 찾을 수 없음') 발생합니다.
+ * 이 경우, 본 예외 객체의 {@code awsErrorCode}, {@code awsRequestId}, {@code awsExtendedRequestId}, {@code httpStatusCode} 필드들은
+ * AWS로부터 받은 상세한 컨텍스트 정보를 가능한 만큼 포함합니다.</li>
  *
- * <li><b>클라이언트 오류 (Client Errors):</b> 요청이 S3 서비스에 도달하기 전에 실패한 경우
- * (예: 네트워크 연결 실패) 발생합니다. 이러한 경우, AWS 관련 상세 오류 정보는 존재하지 않으므로
- * 이 예외의 해당 필드들은 {@code null} 또는 기본값(-1)을 갖게 됩니다.</li>
+ * <li><b>클라이언트 오류 (Client Errors):</b>
+ * 요청이 S3 서비스에 도달하기 전에 실패한 경우 (예: 네트워크 연결 실패) 발생합니다.
+ * 이 경우, AWS 관련 상세 오류 정보는 존재하지 않으므로,
+ * 본 예외 객체의 {@code awsErrorCode}, {@code awsRequestId}, {@code awsExtendedRequestId}, {@code httpStatusCode} 필드들은
+ * {@code null} 또는 기본값(-1)을 갖습니다.</li>
  * </ul>
- * 이 통합된 접근 방식을 통해 라이브러리 사용자는 모든 S3 관련 문제를 일관된 `catch` 구문으로 처리하면서도,
- * 상세 정보가 필요할 때는 해당 정보에 접근할 수 있습니다.
+ *
+ * 이 클래스를 상속하는 구체적인 예외들은 어떤 오류가 발생했는지 명확하게 나타냅니다.
+ * (예: {@code S3EntityTooLargeException}, {@code S3BucketNotFoundException})
+*
+ * 이 통합된 접근 방식을 통해 라이브러리 사용자는 모든 S3 관련 문제를 단일 catch 블록으로 일관되게 처리하면서도,
+ * AWS가 제공하는 상세한 오류 정보가 필요할 때는 getter 메서드를 통해 접근할 수 있도록 합니다.
  */
 public class S3OperationException extends RuntimeException {
 
@@ -45,6 +51,10 @@ public class S3OperationException extends RuntimeException {
 
     public String getAwsRequestId() {
         return awsRequestId;
+    }
+
+    public String getAwsExtendedRequestId() {
+        return awsExtendedRequestId;
     }
 
     public int getHttpStatusCode() {

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidAccessKeyException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidAccessKeyException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidAccessKeyException extends RuntimeException {
+public class InvalidAccessKeyException extends ValidationException {
 
     public InvalidAccessKeyException(String message) {
         super(message);

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidBucketNameException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidBucketNameException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidBucketNameException extends RuntimeException {
+public class InvalidBucketNameException extends ValidationException {
 
   public InvalidBucketNameException(String message) {
     super(message);

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidContentLengthException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidContentLengthException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidContentLengthException extends RuntimeException {
+public class InvalidContentLengthException extends ValidationException {
 
     public InvalidContentLengthException(String message) {
         super(message);

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidContentTypeException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidContentTypeException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidContentTypeException extends RuntimeException {
+public class InvalidContentTypeException extends ValidationException {
 
     public InvalidContentTypeException(String message) {
         super(message);

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidFileException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidFileException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidFileException extends RuntimeException {
+public class InvalidFileException extends ValidationException {
     public InvalidFileException(String message) {
         super(message);
     }

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidImageException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidImageException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidImageException extends RuntimeException {
+public class InvalidImageException extends ValidationException {
     public InvalidImageException(String message) {
         super(message);
     }

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidObjectKeyException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidObjectKeyException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidObjectKeyException extends RuntimeException {
+public class InvalidObjectKeyException extends ValidationException {
 
     public InvalidObjectKeyException(String message) {
         super(message);

--- a/src/main/java/org/websoso/s3/exception/validation/InvalidSecretKeyException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/InvalidSecretKeyException.java
@@ -1,6 +1,6 @@
 package org.websoso.s3.exception.validation;
 
-public class InvalidSecretKeyException extends RuntimeException {
+public class InvalidSecretKeyException extends ValidationException {
 
   public InvalidSecretKeyException(String message) {
     super(message);

--- a/src/main/java/org/websoso/s3/exception/validation/ValidationException.java
+++ b/src/main/java/org/websoso/s3/exception/validation/ValidationException.java
@@ -1,0 +1,22 @@
+package org.websoso.s3.exception.validation;
+
+/**
+ * 라이브러리 또는 애플리케이션의 내부 로직을 실행하기 전, 입력 값의 유효성 검사에 실패했을 때 발생하는 예외의 최상위 기본 클래스입니다.
+ * <p>
+ * 이 예외는 잘못된 데이터가 핵심 비즈니스 로직으로 전달되는 것을 막는 '가드(Guard)' 역할을 합니다.
+ * 주로 외부로부터 받은 데이터가 사전에 정의된 규칙이나 제약 조건을 위반했을 경우 사용됩니다.
+ *
+ * 이 클래스를 상속하는 구체적인 예외들은 어떤 유효성 검사 규칙이 위반되었는지 명확하게 나타냅니다.
+ * (예: {@code InvalidBucketNameException}, {@code InvalidFileException})
+ */
+public class ValidationException extends RuntimeException {
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
+++ b/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
@@ -3,7 +3,7 @@ package org.websoso.s3.core;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.websoso.s3.core.strategy.FastMimeTypeDetectionStrategy;
+import org.websoso.s3.core.strategy.PreciseMimeTypeDetectionStrategy;
 import org.websoso.s3.exception.validation.InvalidContentTypeException;
 import org.websoso.s3.exception.validation.InvalidImageException;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -17,13 +17,15 @@ import static org.mockito.Mockito.mock;
 class S3ImageServiceTest {
 
     private S3ImageService imageService;
+    // private S3ImageService imageService;
 
     @BeforeEach
     void setUp() {
         S3Client s3Client = mock(S3Client.class);
         String bucket = "test-bucket";
 
-        imageService = new S3ImageService(s3Client, bucket, new FastMimeTypeDetectionStrategy());
+        imageService = new S3ImageService(s3Client, bucket);
+        // imageService = new S3ImageService(s3Client, bucket, new PreciseMimeTypeDetectionStrategy());
     }
 
     @DisplayName("지원하지 않는 확장자일 경우 예외를 던진다")


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#3 -> dev
- close #3

## Key Changes
- 각 예외 패키지(aws.s3, aws.global, validation)에 대한 최상위 예외 클래스를 정의하여 예외 처리 계층 구조를 명확히 합니다.
  - `aws/s3/S3OperationException.java` : S3 관련 모든 작업 예외의 최상위 예외 클래스
  - `aws/global/AwsGlobalException.java` : AWS 전역 설정 관련 예외의 최상위 예외 클래스
  - `validation/ValidationException.java` : 입력값 검증 관련 예외의 최상위 예외 클래스
- 각 최상위 예외 클래스에 Javadoc 주석을 상세하게 추가하여 그 목적과 사용법을 명확히 설명합니다.


## To Reviewers


## References
