### PR TITLE
[REFACTOR] S3ImageService 인스턴스 생성 시 디폴트 전략(FAST) 지정 방식 단순화

### DIFF
--- a/src/main/java/org/websoso/s3/config/S3DetectionProperties.java
+++ b/src/main/java/org/websoso/s3/config/S3DetectionProperties.java
@@ -31,11 +31,11 @@ public class S3DetectionProperties {
     }
 
     /**
-     * MIME 감지 전략을 설정합니다. null이 들어올 경우 기본값 {@link MimeDetection#FAST}로 대체됩니다.
+     * MIME 감지 전략을 설정합니다.
      *
      * @param mimeDetection 감지 전략
      */
     public void setMimeDetection(MimeDetection mimeDetection) {
-        this.mimeDetection = (mimeDetection != null) ? mimeDetection : MimeDetection.FAST;
+        this.mimeDetection = mimeDetection;
     }
 }

--- a/src/main/java/org/websoso/s3/core/S3ImageService.java
+++ b/src/main/java/org/websoso/s3/core/S3ImageService.java
@@ -1,5 +1,6 @@
 package org.websoso.s3.core;
 
+import org.websoso.s3.core.strategy.FastMimeTypeDetectionStrategy;
 import org.websoso.s3.core.strategy.MimeTypeDetectionStrategy;
 import org.websoso.s3.exception.validation.InvalidImageException;
 import org.websoso.s3.modle.Bucket;
@@ -35,6 +36,16 @@ public class S3ImageService implements S3DefaultService {
         this.remover = new S3Remover(s3Client, bucketWrapper);
         this.reader = new S3Reader(s3Client, bucketWrapper);
         this.mimeDetector = mimeDetector;
+    }
+
+    public S3ImageService(S3Client s3Client, String bucket) {
+        Bucket bucketWrapper = Bucket.of(bucket);
+        FastMimeTypeDetectionStrategy fastMimeTypeDetectionStrategy = new FastMimeTypeDetectionStrategy();
+
+        this.uploader = new S3Uploader(s3Client, bucketWrapper);
+        this.remover = new S3Remover(s3Client, bucketWrapper);
+        this.reader = new S3Reader(s3Client, bucketWrapper);
+        this.mimeDetector = fastMimeTypeDetectionStrategy;
     }
 
     /**

--- a/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
+++ b/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
@@ -3,7 +3,7 @@ package org.websoso.s3.core;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.websoso.s3.core.strategy.FastMimeTypeDetectionStrategy;
+import org.websoso.s3.core.strategy.PreciseMimeTypeDetectionStrategy;
 import org.websoso.s3.exception.validation.InvalidContentTypeException;
 import org.websoso.s3.exception.validation.InvalidImageException;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -17,13 +17,15 @@ import static org.mockito.Mockito.mock;
 class S3ImageServiceTest {
 
     private S3ImageService imageService;
+    // private S3ImageService imageService;
 
     @BeforeEach
     void setUp() {
         S3Client s3Client = mock(S3Client.class);
         String bucket = "test-bucket";
 
-        imageService = new S3ImageService(s3Client, bucket, new FastMimeTypeDetectionStrategy());
+        imageService = new S3ImageService(s3Client, bucket);
+        // imageService = new S3ImageService(s3Client, bucket, new PreciseMimeTypeDetectionStrategy());
     }
 
     @DisplayName("지원하지 않는 확장자일 경우 예외를 던진다")

--- a/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
+++ b/src/test/java/org/websoso/s3/core/S3ImageServiceTest.java
@@ -3,7 +3,6 @@ package org.websoso.s3.core;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.websoso.s3.core.strategy.PreciseMimeTypeDetectionStrategy;
 import org.websoso.s3.exception.validation.InvalidContentTypeException;
 import org.websoso.s3.exception.validation.InvalidImageException;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -17,7 +16,6 @@ import static org.mockito.Mockito.mock;
 class S3ImageServiceTest {
 
     private S3ImageService imageService;
-    // private S3ImageService imageService;
 
     @BeforeEach
     void setUp() {
@@ -25,7 +23,6 @@ class S3ImageServiceTest {
         String bucket = "test-bucket";
 
         imageService = new S3ImageService(s3Client, bucket);
-        // imageService = new S3ImageService(s3Client, bucket, new PreciseMimeTypeDetectionStrategy());
     }
 
     @DisplayName("지원하지 않는 확장자일 경우 예외를 던진다")


### PR DESCRIPTION
## Related Issue

<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->

- refactor/#11 -> dev
- close #11

## Key Changes

- `S3ImageService` 생성 시, 기본 전략을 사용하려는 경우에도 불필요한 객체 생성 및 주입 과정을 거쳐야 했던 기존의 불편함을 개선하여, 라이브러리 사용자가 더 직관적이고 편리하게 `S3ImageService`를 사용할 수 있도록 했습니다.
- **S3ImageService 객체 생성 간소화**: `S3ImageService` 생성 시 `MimeTypeDetectionStrategy`를 전달하지 않으면, 자동으로 기본값인 `FAST` 전략이 적용됩니다. 이를 위해 생성자를 오버로딩했습니다.
- **명확성 강화**: `setMimeDetection()` 메서드가 `null`을 인자로 받을 수 없도록 수정했습니다. 이제 `MimeDetection.FAST` 또는 `MimeDetection.PRECISE`만 명시적으로 선택해야 하므로, 오용 가능성이 줄어듭니다.

## To Reviewers

- 이번 변경으로 이미지 서비스에 대한 라이브러리 사용법이 아래와 같이 개선되었습니다.
    - Before
        
        ```java
        // 일반 파일 서비스
        S3FileService fileService = new S3FileService(s3Client, "your-bucket-name");
        
        // 이미지 서비스 - 기본: 빠른 전략
        S3DetectionProperties detectionProps = new S3DetectionProperties();
        detectionProps.setMimeDetection(S3DetectionProperties.MimeDetection.FAST); // detectionProps.setMimeDetection(null); 가능
        MimeTypeDetectionStrategy mimeDetector = MimeTypeDetectionStrategyFactory.from(detectionProps);
        S3ImageService imageService = new S3ImageService(s3Client, "your-bucket-name", mimeDetector);
        
        // 이미지 서비스 - 지정: 정밀 전략
        S3DetectionProperties detectionProps = new S3DetectionProperties();
        detectionProps.setMimeDetection(S3DetectionProperties.MimeDetection.PRECISE);
        MimeTypeDetectionStrategy mimeDetector = MimeTypeDetectionStrategyFactory.from(detectionProps);
        S3ImageService imageService = new S3ImageService(s3Client, "your-bucket-name", mimeDetector);
        ```
        
    
    - After
        
        ```java
        // 일반 파일 서비스
        S3FileService fileService = new S3FileService(s3Client, "your-bucket-name");
        
        // 이미지 서비스 - 기본: 빠른 전략
        S3ImageService imageService = new S3ImageService(s3Client, "your-bucket-name");
        
        // 이미지 서비스 - 지정: 빠른 전략
        S3DetectionProperties detectionProps = new S3DetectionProperties();
        detectionProps.setMimeDetection(S3DetectionProperties.MimeDetection.FAST);
        MimeTypeDetectionStrategy mimeDetector = MimeTypeDetectionStrategyFactory.from(detectionProps);
        S3ImageService imageService = new S3ImageService(s3Client, "your-bucket-name", mimeDetector);

        // 이미지 서비스 - 지정: 정밀 전략
        S3DetectionProperties detectionProps = new S3DetectionProperties();
        detectionProps.setMimeDetection(S3DetectionProperties.MimeDetection.PRECISE);
        MimeTypeDetectionStrategy mimeDetector = MimeTypeDetectionStrategyFactory.from(detectionProps);
        S3ImageService imageService = new S3ImageService(s3Client, "your-bucket-name", mimeDetector);
        ```
        
- README에는 #15 에서 위 사항 반영해두었습니다. 

## References