### PR TITLE
[BUG] S3FileService: 업로드 실패 시 성공 결과 반환

### DIFF
--- a/src/main/java/org/websoso/s3/core/S3FileService.java
+++ b/src/main/java/org/websoso/s3/core/S3FileService.java
@@ -47,7 +47,7 @@ public class S3FileService implements S3DefaultService {
         S3UploadResponse response = uploader.upload(parsedObjectKey, file);
 
         if (!response.isSuccess()) {
-            S3UploadResult.fail(response);
+            return S3UploadResult.fail(response);
         }
 
         String url = reader.getUrl(parsedObjectKey);
@@ -73,7 +73,7 @@ public class S3FileService implements S3DefaultService {
         S3UploadResponse response = uploader.upload(parsedObjectKey, file, ContentType.of(contentType));
 
         if (!response.isSuccess()) {
-            S3UploadResult.fail(response);
+            return S3UploadResult.fail(response);
         }
 
         String url = reader.getUrl(parsedObjectKey);
@@ -100,7 +100,7 @@ public class S3FileService implements S3DefaultService {
         S3UploadResponse response = uploader.upload(parsedObjectKey, inputStream, ContentType.of(contentType), ContentLength.of(contentLength));
 
         if (!response.isSuccess()) {
-            S3UploadResult.fail(response);
+            return S3UploadResult.fail(response);
         }
 
         String url = reader.getUrl(parsedObjectKey);

--- a/src/test/java/org/websoso/s3/core/S3FileServiceTest.java
+++ b/src/test/java/org/websoso/s3/core/S3FileServiceTest.java
@@ -1,0 +1,154 @@
+package org.websoso.s3.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.websoso.s3.exception.validation.InvalidFileException;
+import org.websoso.s3.exception.validation.InvalidObjectKeyException;
+import org.websoso.s3.modle.S3UploadResult;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+class S3FileServiceTest {
+
+    private S3Client s3Client;
+    private S3FileService fileService;
+
+    @BeforeEach
+    void setUp() {
+        s3Client = mock(S3Client.class);
+        fileService = new S3FileService(s3Client, "test-bucket");
+    }
+
+    @DisplayName("[BUG-1] upload(File) - S3 실패 응답 시 isSuccess=false를 반환한다")
+    @Test
+    void uploadFile_whenS3ReturnsFailure_returnsFailResult() {
+        // given
+        File file = new File("src/test/resources/test.png");
+        stubFailingPutObject();
+
+        // when
+        S3UploadResult result = fileService.upload("test/test.png", file);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        verify(s3Client, never()).utilities(); // URL 조회가 호출되어선 안 된다
+    }
+
+    @DisplayName("[BUG-1] upload(File, contentType) - S3 실패 응답 시 isSuccess=false를 반환한다")
+    @Test
+    void uploadFileWithContentType_whenS3ReturnsFailure_returnsFailResult() {
+        // given
+        File file = new File("src/test/resources/test.png");
+        stubFailingPutObject();
+
+        // when
+        S3UploadResult result = fileService.upload("test/test.png", file, "image/png");
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        verify(s3Client, never()).utilities();
+    }
+
+    @DisplayName("[BUG-1] upload(InputStream) - S3 실패 응답 시 isSuccess=false를 반환한다")
+    @Test
+    void uploadInputStream_whenS3ReturnsFailure_returnsFailResult() {
+        // given
+        ByteArrayInputStream stream = new ByteArrayInputStream(new byte[]{1, 2, 3});
+        stubFailingPutObject();
+
+        // when
+        S3UploadResult result = fileService.upload("test/file.bin", stream, "application/octet-stream", 3);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        verify(s3Client, never()).utilities();
+    }
+
+    @DisplayName("upload(File) - S3 성공 시 isSuccess=true이고 URL을 반환한다")
+    @Test
+    void uploadFile_whenS3ReturnsSuccess_returnsSuccessResult() throws MalformedURLException {
+        // given
+        File file = new File("src/test/resources/test.png");
+        String expectedUrl = "https://test-bucket.s3.amazonaws.com/test/test.png";
+        stubSuccessfulPutObject("\"etag-abc\"");
+        stubGetUrl(expectedUrl);
+
+        // when
+        S3UploadResult result = fileService.upload("test/test.png", file);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.url()).isEqualTo(expectedUrl);
+        assertThat(result.eTag()).isEqualTo("\"etag-abc\"");
+    }
+
+    @DisplayName("key가 null이면 InvalidObjectKeyException을 던진다")
+    @Test
+    void upload_nullKey_throwsIllegalArgumentException() {
+        File file = new File("src/test/resources/test.png");
+
+        assertThatThrownBy(() -> fileService.upload(null, file))
+                .isInstanceOf(InvalidObjectKeyException.class);
+    }
+
+    @DisplayName("존재하지 않는 파일이면 InvalidFileException을 던진다")
+    @Test
+    void upload_nonExistentFile_throwsInvalidFileException() {
+        File file = new File("does-not-exist.png");
+
+        assertThatThrownBy(() -> fileService.upload("key", file))
+                .isInstanceOf(InvalidFileException.class);
+    }
+
+    private void stubFailingPutObject() {
+        SdkHttpResponse failHttp = mock(SdkHttpResponse.class);
+        when(failHttp.isSuccessful()).thenReturn(false);
+        when(failHttp.statusCode()).thenReturn(403);
+        when(failHttp.statusText()).thenReturn(Optional.of("Forbidden"));
+
+        PutObjectResponse failResponse = mock(PutObjectResponse.class);
+        when(failResponse.sdkHttpResponse()).thenReturn(failHttp);
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(failResponse);
+    }
+
+    private void stubSuccessfulPutObject(String eTag) {
+        SdkHttpResponse okHttp = mock(SdkHttpResponse.class);
+        when(okHttp.isSuccessful()).thenReturn(true);
+        when(okHttp.statusCode()).thenReturn(200);
+        when(okHttp.statusText()).thenReturn(Optional.of("OK"));
+
+        PutObjectResponse okResponse = mock(PutObjectResponse.class);
+        when(okResponse.sdkHttpResponse()).thenReturn(okHttp);
+        when(okResponse.eTag()).thenReturn(eTag);
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(okResponse);
+    }
+
+    private void stubGetUrl(String url) throws MalformedURLException {
+        S3Utilities utilities = mock(S3Utilities.class);
+        when(s3Client.utilities()).thenReturn(utilities);
+        when(utilities.getUrl(any(GetUrlRequest.class))).thenReturn(new URL(url));
+    }
+}


### PR DESCRIPTION
## Related Issue

<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->

- bug/#19 -> dev
- close #19

## Key Changes

S3DefaultService의 구현체로 S3FileService를 사용할 경우 파일 업로드에 실패해도 Success 객체를 반환하는 문제가 있었습니다.

따라서 업로드 실패시에 fail 객체를 반환하도록 수정하였습니다.

테스트를 통해서 fail 객체를 반환하는 것 또한 확인하였습니다.

## To Reviewers

## References