### PR TITLE
[BUG] S3ClientFactory: 비결정론적 캐시 키로 인한 캐시 미스

### DIFF
--- a/src/main/java/org/websoso/s3/config/S3AccessConfig.java
+++ b/src/main/java/org/websoso/s3/config/S3AccessConfig.java
@@ -163,4 +163,8 @@ public class S3AccessConfig {
     public AwsCredentialsProvider getCredentialsProvider() {
         return credentialsProvider;
     }
+
+    public String getAccessKey() {
+        return accessKey.getValue();
+    }
 }

--- a/src/main/java/org/websoso/s3/factory/S3ClientFactory.java
+++ b/src/main/java/org/websoso/s3/factory/S3ClientFactory.java
@@ -36,7 +36,8 @@ public class S3ClientFactory {
     }
 
     private static String generateCacheKey(S3AccessConfig s3AccessConfig) {
-        return s3AccessConfig.getRegion().id() + "-" + s3AccessConfig.getCredentialsProvider().hashCode();
+        String accessKey = s3AccessConfig.getAccessKey();
+        return s3AccessConfig.getRegion().id() + ":" + (accessKey != null ? accessKey : "default");
     }
 
     private static S3Client createS3Client(S3AccessConfig s3AccessConfig) {

--- a/src/main/java/org/websoso/s3/factory/S3ClientFactory.java
+++ b/src/main/java/org/websoso/s3/factory/S3ClientFactory.java
@@ -46,4 +46,8 @@ public class S3ClientFactory {
                 .credentialsProvider(s3AccessConfig.getCredentialsProvider())
                 .build();
     }
+
+    static void clearCache() {
+        clientCache.clear();
+    }
 }

--- a/src/test/java/org/websoso/s3/factory/S3ClientFactoryTest.java
+++ b/src/test/java/org/websoso/s3/factory/S3ClientFactoryTest.java
@@ -28,11 +28,13 @@ class S3ClientFactoryTest {
 
     @BeforeEach
     void setUp() {
+        S3ClientFactory.clearCache();
         mockCredentials = mock(AwsCredentialsProvider.class);
         s3AccessConfig = mock(S3AccessConfig.class);
 
         when(s3AccessConfig.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
         when(s3AccessConfig.getCredentialsProvider()).thenReturn(mockCredentials);
+        when(s3AccessConfig.getAccessKey()).thenReturn("test-access-key");
     }
 
     @DisplayName("같은 S3Config로 여러 번 getS3Client() 호출 시 동일한 S3Client를 반환한다.")
@@ -53,14 +55,17 @@ class S3ClientFactoryTest {
     void shouldReturnSameS3ClientForConfigsWithSameRegionAndCredentials() {
         // given
         Region region = Region.AP_NORTHEAST_2;
+        String accessKey = "shared-access-key";
 
         S3AccessConfig config1 = mock(S3AccessConfig.class);
         when(config1.getRegion()).thenReturn(region);
         when(config1.getCredentialsProvider()).thenReturn(mockCredentials);
+        when(config1.getAccessKey()).thenReturn(accessKey);
 
         S3AccessConfig config2 = mock(S3AccessConfig.class);
         when(config2.getRegion()).thenReturn(region);
         when(config2.getCredentialsProvider()).thenReturn(mockCredentials);
+        when(config2.getAccessKey()).thenReturn(accessKey);
 
         // when
         S3Client client1 = S3ClientFactory.getS3Client(config1);
@@ -99,15 +104,15 @@ class S3ClientFactoryTest {
     @Test
     void shouldCreateDifferentS3ClientInstancesForDifferentConfigs() {
         // given
-        AwsCredentialsProvider credentials1 = mock(AwsCredentialsProvider.class);
         S3AccessConfig config1 = mock(S3AccessConfig.class);
         when(config1.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
-        when(config1.getCredentialsProvider()).thenReturn(credentials1);
+        when(config1.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config1.getAccessKey()).thenReturn("key-a");
 
-        AwsCredentialsProvider credentials2 = mock(AwsCredentialsProvider.class);
         S3AccessConfig config2 = mock(S3AccessConfig.class);
         when(config2.getRegion()).thenReturn(Region.US_WEST_1);
-        when(config2.getCredentialsProvider()).thenReturn(credentials2);
+        when(config2.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config2.getAccessKey()).thenReturn("key-b");
 
         // when
         S3Client client1 = S3ClientFactory.getS3Client(config1);
@@ -117,6 +122,72 @@ class S3ClientFactoryTest {
         assertThat(client1).isNotNull();
         assertThat(client2).isNotNull();
         assertThat(client1).isNotSameAs(client2);
+    }
+
+    @DisplayName("동일 리전 + 동일 accessKey → 동일 S3Client를 반환한다")
+    @Test
+    void shouldReturnSameClientForSameRegionAndSameAccessKey() {
+        // given
+        S3AccessConfig config1 = mock(S3AccessConfig.class);
+        when(config1.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
+        when(config1.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config1.getAccessKey()).thenReturn("AKIAIOSFODNN7EXAMPLE");
+
+        S3AccessConfig config2 = mock(S3AccessConfig.class);
+        when(config2.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
+        when(config2.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config2.getAccessKey()).thenReturn("AKIAIOSFODNN7EXAMPLE");
+
+        // when
+        S3Client client1 = S3ClientFactory.getS3Client(config1);
+        S3Client client2 = S3ClientFactory.getS3Client(config2);
+
+        // then
+        assertThat(client1).isSameAs(client2);
+    }
+
+    @DisplayName("동일 리전 + 다른 accessKey → 서로 다른 S3Client를 반환한다")
+    @Test
+    void shouldReturnDifferentClientForSameRegionButDifferentAccessKey() {
+        // given
+        S3AccessConfig config1 = mock(S3AccessConfig.class);
+        when(config1.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
+        when(config1.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config1.getAccessKey()).thenReturn("AKIA_KEY_ONE");
+
+        S3AccessConfig config2 = mock(S3AccessConfig.class);
+        when(config2.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
+        when(config2.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config2.getAccessKey()).thenReturn("AKIA_KEY_TWO");
+
+        // when
+        S3Client client1 = S3ClientFactory.getS3Client(config1);
+        S3Client client2 = S3ClientFactory.getS3Client(config2);
+
+        // then
+        assertThat(client1).isNotSameAs(client2);
+    }
+
+    @DisplayName("accessKey가 null인 config (기본 자격증명)는 반복 호출 시 동일한 S3Client를 반환한다")
+    @Test
+    void shouldReturnSameClientForDefaultCredentialsOnRepeatedCalls() {
+        // given
+        S3AccessConfig config1 = mock(S3AccessConfig.class);
+        when(config1.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
+        when(config1.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config1.getAccessKey()).thenReturn(null); // DefaultCredentialsProvider 경로
+
+        S3AccessConfig config2 = mock(S3AccessConfig.class);
+        when(config2.getRegion()).thenReturn(Region.AP_NORTHEAST_2);
+        when(config2.getCredentialsProvider()).thenReturn(mock(AwsCredentialsProvider.class));
+        when(config2.getAccessKey()).thenReturn(null);
+
+        // when
+        S3Client client1 = S3ClientFactory.getS3Client(config1);
+        S3Client client2 = S3ClientFactory.getS3Client(config2);
+
+        // then — 두 인스턴스 모두 "ap-northeast-2:default" 키를 공유하므로 동일해야 한다
+        assertThat(client1).isSameAs(client2);
     }
 
 }


### PR DESCRIPTION
## Related Issue

<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->

- bug/#20 -> dev
- close #20 

## Key Changes

S3Client 캐싱 키가 CredentialsProvider 인스턴스의 해시 코드로 생성되고 있었습니다.

이로 인해서, S3Client를 불러오는 과정에서 매번 새로운 캐시 값이 생성되고 저장되는 문제가 있었습니다.

이를 해결하기 위해, 인스턴스의 해시 값이 아닌, Access 키 값과 리전을 조합하도록 변경하였습니다.

## To Reviewers

## References